### PR TITLE
Fix Lab3 typo

### DIFF
--- a/Lab3/Lab3.cpp
+++ b/Lab3/Lab3.cpp
@@ -18,7 +18,7 @@ int main(){
 	ifstream input;
 
 	//allows for 12 inputs to tempdata.dat
-	cout << "Enter 12 temperatures seperated by a space:" << endl;
+        cout << "Enter 12 temperatures separated by a space:" << endl;
 	cin >> t1>>t2>> t3>> t4>> t5>> t6>> t7>> t8>> t9>> t10>> t11>> t12;
 	output.open("tempdata.dat");
 	output << fixed << showpoint<<setprecision(1);


### PR DESCRIPTION
## Summary
- fix "seperated" typo in Lab3 input prompt

## Testing
- `g++ Lab3/Lab3.cpp -o Lab3/Lab3`
- `echo "1 2 3 4 5 6 7 8 9 10 11 12" | ./Lab3/Lab3 | head`

------
https://chatgpt.com/codex/tasks/task_e_68407f40175c832c8f5f15c50a657e22