### PR TITLE
Fix Lab5 file paths

### DIFF
--- a/Lab5/Lab5.cpp
+++ b/Lab5/Lab5.cpp
@@ -1,4 +1,5 @@
-//Lab5.cpp prints a bar graph of 24 temperatures to both a text file (barGraph.txt) and the console window
+//Lab5.cpp prints a bar graph of 24 temperatures to both a text file
+// (Lab5/barGraph.txt) and the console window
 //CSIS 111-02
 
 //Include statements
@@ -12,13 +13,14 @@ using namespace std;
 
 int main(){
 	cout << "HaiDang Phan -- Lab 5" << endl;
-	cout << "Bar Graph also printed to text file (barGraph.txt)"<<endl<<endl;
+        cout << "Bar Graph also printed to text file (Lab5/barGraph.txt)"<<endl<<endl;
 
 	//I have read and understood the lab submittal policy
 
 	ifstream input;
 	ofstream output;
-	output.open("barGraph.txt");
+        // Output written to Lab5/barGraph.txt when run from repository root
+        output.open("Lab5/barGraph.txt");
 	//variable declarations
 	int temp;
 	int stars;
@@ -27,7 +29,8 @@ int main(){
 	int countSpace;
 
 	//printing the header and scale
-	input.open("tempData.txt");
+        // Input temperatures read from Lab5/tempData.txt
+        input.open("Lab5/tempData.txt");
 	output << "Temperatures for 24 hours:" << endl
 		 << "    -30        0         30        60        90        120" << endl
 		 << "     |---------|---------|---------|---------|---------|" << endl;

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # csis111
+
+## Lab5 notes
+
+When running `Lab5/Lab5.cpp` from the repository root, the program reads
+temperature data from `Lab5/tempData.txt` and writes the resulting bar graph
+to `Lab5/barGraph.txt`.


### PR DESCRIPTION
## Summary
- fix Lab5 tempData.txt and barGraph.txt paths so program works from repo root
- mention Lab5 output file in README
- note output location in Lab5.cpp comments

## Testing
- `python3 Lab6/test_rot13.py`
- `g++ Lab5/Lab5.cpp -o Lab5/Lab5 && ./Lab5/Lab5`

------
https://chatgpt.com/codex/tasks/task_e_6840837539a8832cbef93a9a076bebf8