### PR TITLE
Fix pytest rot13 test

### DIFF
--- a/Lab6/test_rot13.py
+++ b/Lab6/test_rot13.py
@@ -1,5 +1,4 @@
 import subprocess
-import sys
 from pathlib import Path
 
 # Expected ROT13 output for contents of input.txt
@@ -13,43 +12,30 @@ EXECUTABLE = LAB_DIR / "rot13_test"
 INPUT_FILE = LAB_DIR / "input.txt"
 OUTPUT_FILE = LAB_DIR / "output.rot13"
 
-# Compile the program
-compile_proc = subprocess.run([
-    "g++",
-    str(CPP_FILE),
-    "-o",
-    str(EXECUTABLE),
-], capture_output=True, text=True)
+def test_rot13():
+    # Compile the program
+    compile_proc = subprocess.run([
+        "g++",
+        str(CPP_FILE),
+        "-o",
+        str(EXECUTABLE),
+    ], capture_output=True, text=True)
+    assert (
+        compile_proc.returncode == 0
+    ), f"Compilation failed:\n{compile_proc.stdout}{compile_proc.stderr}"
 
-if compile_proc.returncode != 0:
-    sys.stderr.write("Compilation failed:\n")
-    sys.stderr.write(compile_proc.stdout)
-    sys.stderr.write(compile_proc.stderr)
-    sys.exit(1)
+    # Run the program providing the input file name
+    run_proc = subprocess.run(
+        [str(EXECUTABLE)],
+        input=f"{INPUT_FILE.name}\n",
+        text=True,
+        cwd=LAB_DIR,
+        capture_output=True,
+    )
+    assert (
+        run_proc.returncode == 0
+    ), f"Execution failed:\n{run_proc.stdout}{run_proc.stderr}"
 
-# Run the program providing the input file name
-run_proc = subprocess.run(
-    [str(EXECUTABLE)],
-    input=f"{INPUT_FILE.name}\n",
-    text=True,
-    cwd=LAB_DIR,
-    capture_output=True,
-)
-
-if run_proc.returncode != 0:
-    sys.stderr.write("Execution failed:\n")
-    sys.stderr.write(run_proc.stdout)
-    sys.stderr.write(run_proc.stderr)
-    sys.exit(1)
-
-# Read produced output
-result = OUTPUT_FILE.read_text()
-
-if result == EXPECTED:
-    print("Rot13 test passed")
-    sys.exit(0)
-else:
-    print("Rot13 test failed")
-    print("Expected:", EXPECTED)
-    print("Got:", result)
-    sys.exit(1)
+    # Read produced output
+    result = OUTPUT_FILE.read_text()
+    assert result == EXPECTED, f"Expected: {EXPECTED!r}\nGot: {result!r}"


### PR DESCRIPTION
## Summary
- run compile and execution steps inside `test_rot13`
- use assertions instead of `sys.exit`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684083772978832cbb1a07caaa141129